### PR TITLE
added stub/dummy implementation for api operations

### DIFF
--- a/gen/client/kov_client.go
+++ b/gen/client/kov_client.go
@@ -25,7 +25,7 @@ const (
 )
 
 // DefaultSchemes are the default schemes found in Meta (info) section of spec file
-var DefaultSchemes = []string{"https"}
+var DefaultSchemes = []string{"http", "https"}
 
 // NewHTTPClient creates a new kov HTTP client.
 func NewHTTPClient(formats strfmt.Registry) *Kov {

--- a/gen/client/operations/create_cluster_responses.go
+++ b/gen/client/operations/create_cluster_responses.go
@@ -23,8 +23,8 @@ type CreateClusterReader struct {
 func (o *CreateClusterReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 
-	case 204:
-		result := NewCreateClusterNoContent()
+	case 202:
+		result := NewCreateClusterAccepted()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -49,24 +49,24 @@ func (o *CreateClusterReader) ReadResponse(response runtime.ClientResponse, cons
 	}
 }
 
-// NewCreateClusterNoContent creates a CreateClusterNoContent with default headers values
-func NewCreateClusterNoContent() *CreateClusterNoContent {
-	return &CreateClusterNoContent{}
+// NewCreateClusterAccepted creates a CreateClusterAccepted with default headers values
+func NewCreateClusterAccepted() *CreateClusterAccepted {
+	return &CreateClusterAccepted{}
 }
 
-/*CreateClusterNoContent handles this case with default header values.
+/*CreateClusterAccepted handles this case with default header values.
 
 create cluster task has been accepted
 */
-type CreateClusterNoContent struct {
+type CreateClusterAccepted struct {
 	Payload models.TaskID
 }
 
-func (o *CreateClusterNoContent) Error() string {
-	return fmt.Sprintf("[POST /clusters][%d] createClusterNoContent  %+v", 204, o.Payload)
+func (o *CreateClusterAccepted) Error() string {
+	return fmt.Sprintf("[POST /clusters][%d] createClusterAccepted  %+v", 202, o.Payload)
 }
 
-func (o *CreateClusterNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *CreateClusterAccepted) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {

--- a/gen/client/operations/delete_cluster_parameters.go
+++ b/gen/client/operations/delete_cluster_parameters.go
@@ -148,13 +148,9 @@ func (o *DeleteClusterParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 
 	}
 
-	// query param name
-	qrName := o.Name
-	qName := qrName
-	if qName != "" {
-		if err := r.SetQueryParam("name", qName); err != nil {
-			return err
-		}
+	// path param name
+	if err := r.SetPathParam("name", o.Name); err != nil {
+		return err
 	}
 
 	if len(res) > 0 {

--- a/gen/client/operations/delete_cluster_responses.go
+++ b/gen/client/operations/delete_cluster_responses.go
@@ -63,7 +63,7 @@ type DeleteClusterNoContent struct {
 }
 
 func (o *DeleteClusterNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /clusters][%d] deleteClusterNoContent  %+v", 204, o.Payload)
+	return fmt.Sprintf("[DELETE /clusters/{name}][%d] deleteClusterNoContent  %+v", 204, o.Payload)
 }
 
 func (o *DeleteClusterNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -90,7 +90,7 @@ type DeleteClusterNotFound struct {
 }
 
 func (o *DeleteClusterNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /clusters][%d] deleteClusterNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[DELETE /clusters/{name}][%d] deleteClusterNotFound  %+v", 404, o.Payload)
 }
 
 func (o *DeleteClusterNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -128,7 +128,7 @@ func (o *DeleteClusterDefault) Code() int {
 }
 
 func (o *DeleteClusterDefault) Error() string {
-	return fmt.Sprintf("[DELETE /clusters][%d] deleteCluster default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[DELETE /clusters/{name}][%d] deleteCluster default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *DeleteClusterDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/gen/client/operations/delete_cluster_responses.go
+++ b/gen/client/operations/delete_cluster_responses.go
@@ -23,8 +23,8 @@ type DeleteClusterReader struct {
 func (o *DeleteClusterReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 
-	case 204:
-		result := NewDeleteClusterNoContent()
+	case 202:
+		result := NewDeleteClusterAccepted()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -49,24 +49,24 @@ func (o *DeleteClusterReader) ReadResponse(response runtime.ClientResponse, cons
 	}
 }
 
-// NewDeleteClusterNoContent creates a DeleteClusterNoContent with default headers values
-func NewDeleteClusterNoContent() *DeleteClusterNoContent {
-	return &DeleteClusterNoContent{}
+// NewDeleteClusterAccepted creates a DeleteClusterAccepted with default headers values
+func NewDeleteClusterAccepted() *DeleteClusterAccepted {
+	return &DeleteClusterAccepted{}
 }
 
-/*DeleteClusterNoContent handles this case with default header values.
+/*DeleteClusterAccepted handles this case with default header values.
 
 delete cluster task has been accepted
 */
-type DeleteClusterNoContent struct {
+type DeleteClusterAccepted struct {
 	Payload models.TaskID
 }
 
-func (o *DeleteClusterNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{name}][%d] deleteClusterNoContent  %+v", 204, o.Payload)
+func (o *DeleteClusterAccepted) Error() string {
+	return fmt.Sprintf("[DELETE /clusters/{name}][%d] deleteClusterAccepted  %+v", 202, o.Payload)
 }
 
-func (o *DeleteClusterNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *DeleteClusterAccepted) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {

--- a/gen/client/operations/operations_client.go
+++ b/gen/client/operations/operations_client.go
@@ -27,7 +27,7 @@ CreateCluster creates a cluster
 
 creates a cluster
 */
-func (a *Client) CreateCluster(params *CreateClusterParams) (*CreateClusterNoContent, error) {
+func (a *Client) CreateCluster(params *CreateClusterParams) (*CreateClusterAccepted, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateClusterParams()
@@ -39,7 +39,7 @@ func (a *Client) CreateCluster(params *CreateClusterParams) (*CreateClusterNoCon
 		PathPattern:        "/clusters",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"https"},
+		Schemes:            []string{"http", "https"},
 		Params:             params,
 		Reader:             &CreateClusterReader{formats: a.formats},
 		Context:            params.Context,
@@ -48,7 +48,7 @@ func (a *Client) CreateCluster(params *CreateClusterParams) (*CreateClusterNoCon
 	if err != nil {
 		return nil, err
 	}
-	return result.(*CreateClusterNoContent), nil
+	return result.(*CreateClusterAccepted), nil
 
 }
 
@@ -66,10 +66,10 @@ func (a *Client) DeleteCluster(params *DeleteClusterParams) (*DeleteClusterNoCon
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "deleteCluster",
 		Method:             "DELETE",
-		PathPattern:        "/clusters",
+		PathPattern:        "/clusters/{name}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"https"},
+		Schemes:            []string{"http", "https"},
 		Params:             params,
 		Reader:             &DeleteClusterReader{formats: a.formats},
 		Context:            params.Context,
@@ -97,7 +97,7 @@ func (a *Client) GetTask(params *GetTaskParams) (*GetTaskOK, error) {
 		PathPattern:        "/tasks/{taskid}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"https"},
+		Schemes:            []string{"http", "https"},
 		Params:             params,
 		Reader:             &GetTaskReader{formats: a.formats},
 		Context:            params.Context,
@@ -127,7 +127,7 @@ func (a *Client) ListClusters(params *ListClustersParams) (*ListClustersOK, erro
 		PathPattern:        "/clusters",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"https"},
+		Schemes:            []string{"http", "https"},
 		Params:             params,
 		Reader:             &ListClustersReader{formats: a.formats},
 		Context:            params.Context,
@@ -154,10 +154,10 @@ func (a *Client) UpdateCluster(params *UpdateClusterParams) (*UpdateClusterNoCon
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "updateCluster",
 		Method:             "PUT",
-		PathPattern:        "/clusters",
+		PathPattern:        "/clusters/{name}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"https"},
+		Schemes:            []string{"http", "https"},
 		Params:             params,
 		Reader:             &UpdateClusterReader{formats: a.formats},
 		Context:            params.Context,

--- a/gen/client/operations/operations_client.go
+++ b/gen/client/operations/operations_client.go
@@ -57,7 +57,7 @@ DeleteCluster deletes a cluster
 
 deletes a cluster with the given name
 */
-func (a *Client) DeleteCluster(params *DeleteClusterParams) (*DeleteClusterNoContent, error) {
+func (a *Client) DeleteCluster(params *DeleteClusterParams) (*DeleteClusterAccepted, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteClusterParams()
@@ -78,7 +78,7 @@ func (a *Client) DeleteCluster(params *DeleteClusterParams) (*DeleteClusterNoCon
 	if err != nil {
 		return nil, err
 	}
-	return result.(*DeleteClusterNoContent), nil
+	return result.(*DeleteClusterAccepted), nil
 
 }
 
@@ -145,7 +145,7 @@ UpdateCluster updates a cluster
 
 updates a cluster with the given update config
 */
-func (a *Client) UpdateCluster(params *UpdateClusterParams) (*UpdateClusterNoContent, error) {
+func (a *Client) UpdateCluster(params *UpdateClusterParams) (*UpdateClusterAccepted, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateClusterParams()
@@ -166,7 +166,7 @@ func (a *Client) UpdateCluster(params *UpdateClusterParams) (*UpdateClusterNoCon
 	if err != nil {
 		return nil, err
 	}
-	return result.(*UpdateClusterNoContent), nil
+	return result.(*UpdateClusterAccepted), nil
 
 }
 

--- a/gen/client/operations/update_cluster_parameters.go
+++ b/gen/client/operations/update_cluster_parameters.go
@@ -72,6 +72,11 @@ type UpdateClusterParams struct {
 
 	*/
 	ClusterUpdateConfig *models.ClusterUpdateConfig
+	/*Name
+	  the cluster name to be deleted
+
+	*/
+	Name string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -133,6 +138,17 @@ func (o *UpdateClusterParams) SetClusterUpdateConfig(clusterUpdateConfig *models
 	o.ClusterUpdateConfig = clusterUpdateConfig
 }
 
+// WithName adds the name to the update cluster params
+func (o *UpdateClusterParams) WithName(name string) *UpdateClusterParams {
+	o.SetName(name)
+	return o
+}
+
+// SetName adds the name to the update cluster params
+func (o *UpdateClusterParams) SetName(name string) {
+	o.Name = name
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *UpdateClusterParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -155,6 +171,11 @@ func (o *UpdateClusterParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 	}
 
 	if err := r.SetBodyParam(o.ClusterUpdateConfig); err != nil {
+		return err
+	}
+
+	// path param name
+	if err := r.SetPathParam("name", o.Name); err != nil {
 		return err
 	}
 

--- a/gen/client/operations/update_cluster_responses.go
+++ b/gen/client/operations/update_cluster_responses.go
@@ -23,8 +23,8 @@ type UpdateClusterReader struct {
 func (o *UpdateClusterReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 
-	case 204:
-		result := NewUpdateClusterNoContent()
+	case 202:
+		result := NewUpdateClusterAccepted()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -49,24 +49,24 @@ func (o *UpdateClusterReader) ReadResponse(response runtime.ClientResponse, cons
 	}
 }
 
-// NewUpdateClusterNoContent creates a UpdateClusterNoContent with default headers values
-func NewUpdateClusterNoContent() *UpdateClusterNoContent {
-	return &UpdateClusterNoContent{}
+// NewUpdateClusterAccepted creates a UpdateClusterAccepted with default headers values
+func NewUpdateClusterAccepted() *UpdateClusterAccepted {
+	return &UpdateClusterAccepted{}
 }
 
-/*UpdateClusterNoContent handles this case with default header values.
+/*UpdateClusterAccepted handles this case with default header values.
 
 update cluster task has been accepted
 */
-type UpdateClusterNoContent struct {
+type UpdateClusterAccepted struct {
 	Payload models.TaskID
 }
 
-func (o *UpdateClusterNoContent) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{name}][%d] updateClusterNoContent  %+v", 204, o.Payload)
+func (o *UpdateClusterAccepted) Error() string {
+	return fmt.Sprintf("[PUT /clusters/{name}][%d] updateClusterAccepted  %+v", 202, o.Payload)
 }
 
-func (o *UpdateClusterNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *UpdateClusterAccepted) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {

--- a/gen/client/operations/update_cluster_responses.go
+++ b/gen/client/operations/update_cluster_responses.go
@@ -63,7 +63,7 @@ type UpdateClusterNoContent struct {
 }
 
 func (o *UpdateClusterNoContent) Error() string {
-	return fmt.Sprintf("[PUT /clusters][%d] updateClusterNoContent  %+v", 204, o.Payload)
+	return fmt.Sprintf("[PUT /clusters/{name}][%d] updateClusterNoContent  %+v", 204, o.Payload)
 }
 
 func (o *UpdateClusterNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -90,7 +90,7 @@ type UpdateClusterNotFound struct {
 }
 
 func (o *UpdateClusterNotFound) Error() string {
-	return fmt.Sprintf("[PUT /clusters][%d] updateClusterNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[PUT /clusters/{name}][%d] updateClusterNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UpdateClusterNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -128,7 +128,7 @@ func (o *UpdateClusterDefault) Code() int {
 }
 
 func (o *UpdateClusterDefault) Error() string {
-	return fmt.Sprintf("[PUT /clusters][%d] updateCluster default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[PUT /clusters/{name}][%d] updateCluster default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *UpdateClusterDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/gen/models/task.go
+++ b/gen/models/task.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// Task an asynchronous task
+// Task an asynchronous tasko
 // swagger:model task
 type Task struct {
 

--- a/gen/restapi/doc.go
+++ b/gen/restapi/doc.go
@@ -1,14 +1,15 @@
-/*Package restapi API Specification for the vSphere Container Cluster Service (VCCS)
+/*Package restapi API Specification for the Kubernetes on vSphere (KOV)
 
-# RESTful API for the vSphere Container Cluster Service (VCCS)
+# RESTful API for the Kubernetes on vSphere (KOV)
 
 
 
     Schemes:
+      http
       https
     Host: localhost
     BasePath: /
-    Version: 0.2.0
+    Version: 0.1.0
 
     Consumes:
     - application/json

--- a/gen/restapi/embedded_spec.go
+++ b/gen/restapi/embedded_spec.go
@@ -19,13 +19,14 @@ func init() {
     "application/json"
   ],
   "schemes": [
+    "http",
     "https"
   ],
   "swagger": "2.0",
   "info": {
-    "description": "# RESTful API for the vSphere Container Cluster Service (VCCS)\n",
-    "title": "API Specification for the vSphere Container Cluster Service (VCCS)",
-    "version": "0.2.0"
+    "description": "# RESTful API for the Kubernetes on vSphere (KOV)\n",
+    "title": "API Specification for the Kubernetes on vSphere (KOV)",
+    "version": "0.1.0"
   },
   "paths": {
     "/clusters": {
@@ -53,6 +54,41 @@ func init() {
           }
         }
       },
+      "post": {
+        "description": "creates a cluster",
+        "summary": "creates a cluster",
+        "operationId": "createCluster",
+        "parameters": [
+          {
+            "$ref": "#/parameters/requestId"
+          },
+          {
+            "description": "the config of the cluster to be created",
+            "name": "clusterConfig",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/clusterConfig"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "create cluster task has been accepted",
+            "schema": {
+              "$ref": "#/definitions/taskId"
+            }
+          },
+          "409": {
+            "$ref": "#/responses/errorClusterNameConflict"
+          },
+          "default": {
+            "$ref": "#/responses/errorDefault"
+          }
+        }
+      }
+    },
+    "/clusters/{name}": {
       "put": {
         "description": "updates a cluster with the given update config",
         "summary": "updates a cluster",
@@ -60,6 +96,14 @@ func init() {
         "parameters": [
           {
             "$ref": "#/parameters/requestId"
+          },
+          {
+            "type": "string",
+            "x-nullable": false,
+            "description": "the cluster name to be deleted",
+            "name": "name",
+            "in": "path",
+            "required": true
           },
           {
             "description": "the new config of the cluster to be updated",
@@ -86,39 +130,6 @@ func init() {
           }
         }
       },
-      "post": {
-        "description": "creates a cluster",
-        "summary": "creates a cluster",
-        "operationId": "createCluster",
-        "parameters": [
-          {
-            "$ref": "#/parameters/requestId"
-          },
-          {
-            "description": "the config of the cluster to be created",
-            "name": "clusterConfig",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/clusterConfig"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "create cluster task has been accepted",
-            "schema": {
-              "$ref": "#/definitions/taskId"
-            }
-          },
-          "409": {
-            "$ref": "#/responses/errorClusterNameConflict"
-          },
-          "default": {
-            "$ref": "#/responses/errorDefault"
-          }
-        }
-      },
       "delete": {
         "description": "deletes a cluster with the given name",
         "summary": "deletes a cluster",
@@ -132,7 +143,7 @@ func init() {
             "x-nullable": false,
             "description": "the cluster name to be deleted",
             "name": "name",
-            "in": "query",
+            "in": "path",
             "required": true
           }
         ],
@@ -490,7 +501,7 @@ func init() {
       }
     },
     "task": {
-      "description": "an asynchronous task",
+      "description": "an asynchronous tasko",
       "type": "object",
       "required": [
         "id",

--- a/gen/restapi/embedded_spec.go
+++ b/gen/restapi/embedded_spec.go
@@ -116,7 +116,7 @@ func init() {
           }
         ],
         "responses": {
-          "204": {
+          "202": {
             "description": "update cluster task has been accepted",
             "schema": {
               "$ref": "#/definitions/taskId"
@@ -148,7 +148,7 @@ func init() {
           }
         ],
         "responses": {
-          "204": {
+          "202": {
             "description": "delete cluster task has been accepted",
             "schema": {
               "$ref": "#/definitions/taskId"

--- a/gen/restapi/operations/create_cluster_responses.go
+++ b/gen/restapi/operations/create_cluster_responses.go
@@ -11,14 +11,14 @@ import (
 	"github.com/supervised-io/kov/gen/models"
 )
 
-// CreateClusterNoContentCode is the HTTP code returned for type CreateClusterNoContent
-const CreateClusterNoContentCode int = 204
+// CreateClusterAcceptedCode is the HTTP code returned for type CreateClusterAccepted
+const CreateClusterAcceptedCode int = 202
 
-/*CreateClusterNoContent create cluster task has been accepted
+/*CreateClusterAccepted create cluster task has been accepted
 
-swagger:response createClusterNoContent
+swagger:response createClusterAccepted
 */
-type CreateClusterNoContent struct {
+type CreateClusterAccepted struct {
 
 	/*
 	  In: Body
@@ -26,26 +26,26 @@ type CreateClusterNoContent struct {
 	Payload models.TaskID `json:"body,omitempty"`
 }
 
-// NewCreateClusterNoContent creates CreateClusterNoContent with default headers values
-func NewCreateClusterNoContent() *CreateClusterNoContent {
-	return &CreateClusterNoContent{}
+// NewCreateClusterAccepted creates CreateClusterAccepted with default headers values
+func NewCreateClusterAccepted() *CreateClusterAccepted {
+	return &CreateClusterAccepted{}
 }
 
-// WithPayload adds the payload to the create cluster no content response
-func (o *CreateClusterNoContent) WithPayload(payload models.TaskID) *CreateClusterNoContent {
+// WithPayload adds the payload to the create cluster accepted response
+func (o *CreateClusterAccepted) WithPayload(payload models.TaskID) *CreateClusterAccepted {
 	o.Payload = payload
 	return o
 }
 
-// SetPayload sets the payload to the create cluster no content response
-func (o *CreateClusterNoContent) SetPayload(payload models.TaskID) {
+// SetPayload sets the payload to the create cluster accepted response
+func (o *CreateClusterAccepted) SetPayload(payload models.TaskID) {
 	o.Payload = payload
 }
 
 // WriteResponse to the client
-func (o *CreateClusterNoContent) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+func (o *CreateClusterAccepted) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
-	rw.WriteHeader(204)
+	rw.WriteHeader(202)
 	payload := o.Payload
 	if err := producer.Produce(rw, payload); err != nil {
 		panic(err) // let the recovery middleware deal with this

--- a/gen/restapi/operations/delete_cluster.go
+++ b/gen/restapi/operations/delete_cluster.go
@@ -27,7 +27,7 @@ func NewDeleteCluster(ctx *middleware.Context, handler DeleteClusterHandler) *De
 	return &DeleteCluster{Context: ctx, Handler: handler}
 }
 
-/*DeleteCluster swagger:route DELETE /clusters deleteCluster
+/*DeleteCluster swagger:route DELETE /clusters/{name} deleteCluster
 
 deletes a cluster
 

--- a/gen/restapi/operations/delete_cluster_parameters.go
+++ b/gen/restapi/operations/delete_cluster_parameters.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
-	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/validate"
 
@@ -37,7 +36,7 @@ type DeleteClusterParams struct {
 	XRequestID *string
 	/*the cluster name to be deleted
 	  Required: true
-	  In: query
+	  In: path
 	*/
 	Name string
 }
@@ -48,14 +47,12 @@ func (o *DeleteClusterParams) BindRequest(r *http.Request, route *middleware.Mat
 	var res []error
 	o.HTTPRequest = r
 
-	qs := runtime.Values(r.URL.Query())
-
 	if err := o.bindXRequestID(r.Header[http.CanonicalHeaderKey("X-Request-Id")], true, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
-	qName, qhkName, _ := qs.GetOK("name")
-	if err := o.bindName(qName, qhkName, route.Formats); err != nil {
+	rName, rhkName, _ := route.Params.GetOK("name")
+	if err := o.bindName(rName, rhkName, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -93,15 +90,9 @@ func (o *DeleteClusterParams) validateXRequestID(formats strfmt.Registry) error 
 }
 
 func (o *DeleteClusterParams) bindName(rawData []string, hasKey bool, formats strfmt.Registry) error {
-	if !hasKey {
-		return errors.Required("name", "query")
-	}
 	var raw string
 	if len(rawData) > 0 {
 		raw = rawData[len(rawData)-1]
-	}
-	if err := validate.RequiredString("name", "query", raw); err != nil {
-		return err
 	}
 
 	o.Name = raw

--- a/gen/restapi/operations/delete_cluster_responses.go
+++ b/gen/restapi/operations/delete_cluster_responses.go
@@ -11,14 +11,14 @@ import (
 	"github.com/supervised-io/kov/gen/models"
 )
 
-// DeleteClusterNoContentCode is the HTTP code returned for type DeleteClusterNoContent
-const DeleteClusterNoContentCode int = 204
+// DeleteClusterAcceptedCode is the HTTP code returned for type DeleteClusterAccepted
+const DeleteClusterAcceptedCode int = 202
 
-/*DeleteClusterNoContent delete cluster task has been accepted
+/*DeleteClusterAccepted delete cluster task has been accepted
 
-swagger:response deleteClusterNoContent
+swagger:response deleteClusterAccepted
 */
-type DeleteClusterNoContent struct {
+type DeleteClusterAccepted struct {
 
 	/*
 	  In: Body
@@ -26,26 +26,26 @@ type DeleteClusterNoContent struct {
 	Payload models.TaskID `json:"body,omitempty"`
 }
 
-// NewDeleteClusterNoContent creates DeleteClusterNoContent with default headers values
-func NewDeleteClusterNoContent() *DeleteClusterNoContent {
-	return &DeleteClusterNoContent{}
+// NewDeleteClusterAccepted creates DeleteClusterAccepted with default headers values
+func NewDeleteClusterAccepted() *DeleteClusterAccepted {
+	return &DeleteClusterAccepted{}
 }
 
-// WithPayload adds the payload to the delete cluster no content response
-func (o *DeleteClusterNoContent) WithPayload(payload models.TaskID) *DeleteClusterNoContent {
+// WithPayload adds the payload to the delete cluster accepted response
+func (o *DeleteClusterAccepted) WithPayload(payload models.TaskID) *DeleteClusterAccepted {
 	o.Payload = payload
 	return o
 }
 
-// SetPayload sets the payload to the delete cluster no content response
-func (o *DeleteClusterNoContent) SetPayload(payload models.TaskID) {
+// SetPayload sets the payload to the delete cluster accepted response
+func (o *DeleteClusterAccepted) SetPayload(payload models.TaskID) {
 	o.Payload = payload
 }
 
 // WriteResponse to the client
-func (o *DeleteClusterNoContent) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+func (o *DeleteClusterAccepted) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
-	rw.WriteHeader(204)
+	rw.WriteHeader(202)
 	payload := o.Payload
 	if err := producer.Produce(rw, payload); err != nil {
 		panic(err) // let the recovery middleware deal with this

--- a/gen/restapi/operations/delete_cluster_urlbuilder.go
+++ b/gen/restapi/operations/delete_cluster_urlbuilder.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/url"
 	golangswaggerpaths "path"
+	"strings"
 )
 
 // DeleteClusterURL generates an URL for the delete cluster operation
@@ -37,19 +38,16 @@ func (o *DeleteClusterURL) SetBasePath(bp string) {
 func (o *DeleteClusterURL) Build() (*url.URL, error) {
 	var result url.URL
 
-	var _path = "/clusters"
-
-	_basePath := o._basePath
-	result.Path = golangswaggerpaths.Join(_basePath, _path)
-
-	qs := make(url.Values)
+	var _path = "/clusters/{name}"
 
 	name := o.Name
 	if name != "" {
-		qs.Set("name", name)
+		_path = strings.Replace(_path, "{name}", name, -1)
+	} else {
+		return nil, errors.New("Name is required on DeleteClusterURL")
 	}
-
-	result.RawQuery = qs.Encode()
+	_basePath := o._basePath
+	result.Path = golangswaggerpaths.Join(_basePath, _path)
 
 	return &result, nil
 }

--- a/gen/restapi/operations/kov_api.go
+++ b/gen/restapi/operations/kov_api.go
@@ -47,7 +47,7 @@ func NewKovAPI(spec *loads.Document) *KovAPI {
 	}
 }
 
-/*KovAPI # RESTful API for the vSphere Container Cluster Service (VCCS)
+/*KovAPI # RESTful API for the Kubernetes on vSphere (KOV)
  */
 type KovAPI struct {
 	spec            *loads.Document
@@ -247,7 +247,7 @@ func (o *KovAPI) initHandlerCache() {
 	if o.handlers["DELETE"] == nil {
 		o.handlers["DELETE"] = make(map[string]http.Handler)
 	}
-	o.handlers["DELETE"]["/clusters"] = NewDeleteCluster(o.context, o.DeleteClusterHandler)
+	o.handlers["DELETE"]["/clusters/{name}"] = NewDeleteCluster(o.context, o.DeleteClusterHandler)
 
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
@@ -262,7 +262,7 @@ func (o *KovAPI) initHandlerCache() {
 	if o.handlers["PUT"] == nil {
 		o.handlers["PUT"] = make(map[string]http.Handler)
 	}
-	o.handlers["PUT"]["/clusters"] = NewUpdateCluster(o.context, o.UpdateClusterHandler)
+	o.handlers["PUT"]["/clusters/{name}"] = NewUpdateCluster(o.context, o.UpdateClusterHandler)
 
 }
 

--- a/gen/restapi/operations/update_cluster.go
+++ b/gen/restapi/operations/update_cluster.go
@@ -27,7 +27,7 @@ func NewUpdateCluster(ctx *middleware.Context, handler UpdateClusterHandler) *Up
 	return &UpdateCluster{Context: ctx, Handler: handler}
 }
 
-/*UpdateCluster swagger:route PUT /clusters updateCluster
+/*UpdateCluster swagger:route PUT /clusters/{name} updateCluster
 
 updates a cluster
 

--- a/gen/restapi/operations/update_cluster_parameters.go
+++ b/gen/restapi/operations/update_cluster_parameters.go
@@ -43,6 +43,11 @@ type UpdateClusterParams struct {
 	  In: body
 	*/
 	ClusterUpdateConfig *models.ClusterUpdateConfig
+	/*the cluster name to be deleted
+	  Required: true
+	  In: path
+	*/
+	Name string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -79,6 +84,11 @@ func (o *UpdateClusterParams) BindRequest(r *http.Request, route *middleware.Mat
 		res = append(res, errors.Required("clusterUpdateConfig", "body"))
 	}
 
+	rName, rhkName, _ := route.Params.GetOK("name")
+	if err := o.bindName(rName, rhkName, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -108,6 +118,17 @@ func (o *UpdateClusterParams) validateXRequestID(formats strfmt.Registry) error 
 	if err := validate.MinLength("X-Request-Id", "header", (*o.XRequestID), 1); err != nil {
 		return err
 	}
+
+	return nil
+}
+
+func (o *UpdateClusterParams) bindName(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	o.Name = raw
 
 	return nil
 }

--- a/gen/restapi/operations/update_cluster_responses.go
+++ b/gen/restapi/operations/update_cluster_responses.go
@@ -11,14 +11,14 @@ import (
 	"github.com/supervised-io/kov/gen/models"
 )
 
-// UpdateClusterNoContentCode is the HTTP code returned for type UpdateClusterNoContent
-const UpdateClusterNoContentCode int = 204
+// UpdateClusterAcceptedCode is the HTTP code returned for type UpdateClusterAccepted
+const UpdateClusterAcceptedCode int = 202
 
-/*UpdateClusterNoContent update cluster task has been accepted
+/*UpdateClusterAccepted update cluster task has been accepted
 
-swagger:response updateClusterNoContent
+swagger:response updateClusterAccepted
 */
-type UpdateClusterNoContent struct {
+type UpdateClusterAccepted struct {
 
 	/*
 	  In: Body
@@ -26,26 +26,26 @@ type UpdateClusterNoContent struct {
 	Payload models.TaskID `json:"body,omitempty"`
 }
 
-// NewUpdateClusterNoContent creates UpdateClusterNoContent with default headers values
-func NewUpdateClusterNoContent() *UpdateClusterNoContent {
-	return &UpdateClusterNoContent{}
+// NewUpdateClusterAccepted creates UpdateClusterAccepted with default headers values
+func NewUpdateClusterAccepted() *UpdateClusterAccepted {
+	return &UpdateClusterAccepted{}
 }
 
-// WithPayload adds the payload to the update cluster no content response
-func (o *UpdateClusterNoContent) WithPayload(payload models.TaskID) *UpdateClusterNoContent {
+// WithPayload adds the payload to the update cluster accepted response
+func (o *UpdateClusterAccepted) WithPayload(payload models.TaskID) *UpdateClusterAccepted {
 	o.Payload = payload
 	return o
 }
 
-// SetPayload sets the payload to the update cluster no content response
-func (o *UpdateClusterNoContent) SetPayload(payload models.TaskID) {
+// SetPayload sets the payload to the update cluster accepted response
+func (o *UpdateClusterAccepted) SetPayload(payload models.TaskID) {
 	o.Payload = payload
 }
 
 // WriteResponse to the client
-func (o *UpdateClusterNoContent) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+func (o *UpdateClusterAccepted) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
-	rw.WriteHeader(204)
+	rw.WriteHeader(202)
 	payload := o.Payload
 	if err := producer.Produce(rw, payload); err != nil {
 		panic(err) // let the recovery middleware deal with this

--- a/gen/restapi/operations/update_cluster_urlbuilder.go
+++ b/gen/restapi/operations/update_cluster_urlbuilder.go
@@ -7,11 +7,16 @@ import (
 	"errors"
 	"net/url"
 	golangswaggerpaths "path"
+	"strings"
 )
 
 // UpdateClusterURL generates an URL for the update cluster operation
 type UpdateClusterURL struct {
+	Name string
+
 	_basePath string
+	// avoid unkeyed usage
+	_ struct{}
 }
 
 // WithBasePath sets the base path for this url builder, only required when it's different from the
@@ -33,8 +38,14 @@ func (o *UpdateClusterURL) SetBasePath(bp string) {
 func (o *UpdateClusterURL) Build() (*url.URL, error) {
 	var result url.URL
 
-	var _path = "/clusters"
+	var _path = "/clusters/{name}"
 
+	name := o.Name
+	if name != "" {
+		_path = strings.Replace(_path, "{name}", name, -1)
+	} else {
+		return nil, errors.New("Name is required on UpdateClusterURL")
+	}
 	_basePath := o._basePath
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/gen/restapi/server.go
+++ b/gen/restapi/server.go
@@ -32,6 +32,7 @@ var defaultSchemes []string
 
 func init() {
 	defaultSchemes = []string{
+		schemeHTTP,
 		schemeHTTPS,
 	}
 }

--- a/pkg/handlers/createcluster.go
+++ b/pkg/handlers/createcluster.go
@@ -1,0 +1,19 @@
+package handlers
+
+import (
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/supervised-io/kov/gen/models"
+	"github.com/supervised-io/kov/gen/restapi/operations"
+)
+
+// CreateCluster is the handler of the create-cluster operation
+type CreateCluster struct {
+	//app kov.Application
+}
+
+// Handle is the handler for the create cluser operation
+func (h *CreateCluster) Handle(params operations.CreateClusterParams) middleware.Responder {
+	// this is a dummy/stub implementation
+	tid := models.TaskID("1234-5678-1234-5678")
+	return operations.NewCreateClusterAccepted().WithPayload(tid)
+}

--- a/pkg/handlers/deletecluster.go
+++ b/pkg/handlers/deletecluster.go
@@ -1,0 +1,19 @@
+package handlers
+
+import (
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/supervised-io/kov/gen/models"
+	"github.com/supervised-io/kov/gen/restapi/operations"
+)
+
+// DeleteCluster is the handler of the create-cluster operation
+type DeleteCluster struct {
+	//app kov.Application
+}
+
+// Handle is the handler for the create cluser operation
+func (h *DeleteCluster) Handle(params operations.DeleteClusterParams) middleware.Responder {
+	// this is a dummy/stub implementation
+	tid := models.TaskID("1111-2222-3333-4444")
+	return operations.NewDeleteClusterAccepted().WithPayload(tid)
+}

--- a/pkg/handlers/gettask.go
+++ b/pkg/handlers/gettask.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/supervised-io/kov/gen/models"
+	"github.com/supervised-io/kov/gen/restapi/operations"
+)
+
+// GetTask is the handler of the get-task operation
+type GetTask struct {
+	//app kov.Application
+}
+
+// Handle is the handler for the get-task operation
+func (h *GetTask) Handle(params operations.GetTaskParams) middleware.Responder {
+	// this is a dummy/stub implementation
+	task := &models.Task{
+		ID:       models.TaskID(params.Taskid),
+		TaskType: models.TaskTypeCreate,
+		State:    models.TaskStateProcessing,
+	}
+	return operations.NewGetTaskOK().WithPayload(task)
+}

--- a/pkg/handlers/listclusters.go
+++ b/pkg/handlers/listclusters.go
@@ -1,0 +1,40 @@
+package handlers
+
+import (
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/swag"
+	"github.com/supervised-io/kov/gen/models"
+	"github.com/supervised-io/kov/gen/restapi/operations"
+)
+
+// ListClusters is the handler of the list-cluster operation
+type ListClusters struct {
+	//app kov.Application
+}
+
+// Handle is the handler for the list cluser operation
+func (h *ListClusters) Handle(params operations.ListClustersParams) middleware.Responder {
+	// this is a dummy/stub implementation
+	clusters := []*models.Cluster{
+		{
+			Status: models.ClusterStatusActive,
+			Config: &models.ClusterConfig{
+				Name:       swag.String("cluster1"),
+				MasterSize: models.InstanceSizeHuge,
+				MaxNodes:   5,
+				MinNodes:   swag.Int32(2),
+			},
+		},
+		{
+			Status: models.ClusterStatusActive,
+			Config: &models.ClusterConfig{
+				Name:       swag.String("cluster2"),
+				MasterSize: models.InstanceSizeSmall,
+				MaxNodes:   3,
+				MinNodes:   swag.Int32(1),
+			},
+		},
+	}
+
+	return operations.NewListClustersOK().WithPayload(clusters)
+}

--- a/pkg/handlers/updatecluster.go
+++ b/pkg/handlers/updatecluster.go
@@ -1,0 +1,19 @@
+package handlers
+
+import (
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/supervised-io/kov/gen/models"
+	"github.com/supervised-io/kov/gen/restapi/operations"
+)
+
+// UpdateCluster is the handler of the create-cluster operation
+type UpdateCluster struct {
+	//app kov.Application
+}
+
+// Handle is the handler for the create cluser operation
+func (h *UpdateCluster) Handle(params operations.UpdateClusterParams) middleware.Responder {
+	// this is a dummy/stub implementation
+	tid := models.TaskID("5555-5555-5555-5555")
+	return operations.NewUpdateClusterAccepted().WithPayload(tid)
+}

--- a/runtime.go
+++ b/runtime.go
@@ -11,7 +11,6 @@ import (
 
 	cjm "github.com/casualjim/middlewares"
 	"github.com/go-openapi/runtime"
-	"github.com/go-openapi/runtime/middleware"
 	"github.com/kardianos/osext"
 	"github.com/supervised-io/kov/gen/restapi/operations"
 	"github.com/supervised-io/kov/pkg/handlers"
@@ -221,16 +220,11 @@ func (d *defaultApplication) RegisterHandlers(api *operations.KovAPI) {
 
 	api.ListClustersHandler = operations.ListClustersHandlerFunc((&handlers.ListClusters{}).Handle)
 
-	api.DeleteClusterHandler = operations.DeleteClusterHandlerFunc(func(params operations.DeleteClusterParams) middleware.Responder {
-		return middleware.NotImplemented("operation .DeleteCluster has not yet been implemented")
-	})
-	api.GetTaskHandler = operations.GetTaskHandlerFunc(func(params operations.GetTaskParams) middleware.Responder {
-		return middleware.NotImplemented("operation .GetTask has not yet been implemented")
-	})
+	api.GetTaskHandler = operations.GetTaskHandlerFunc((&handlers.GetTask{}).Handle)
 
-	api.UpdateClusterHandler = operations.UpdateClusterHandlerFunc(func(params operations.UpdateClusterParams) middleware.Responder {
-		return middleware.NotImplemented("operation .UpdateCluster has not yet been implemented")
-	})
+	api.DeleteClusterHandler = operations.DeleteClusterHandlerFunc((&handlers.DeleteCluster{}).Handle)
+
+	api.UpdateClusterHandler = operations.UpdateClusterHandlerFunc((&handlers.UpdateCluster{}).Handle)
 
 	api.ServerShutdown = func() {}
 

--- a/runtime.go
+++ b/runtime.go
@@ -10,8 +10,11 @@ import (
 	"syscall"
 
 	cjm "github.com/casualjim/middlewares"
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/kardianos/osext"
 	"github.com/supervised-io/kov/gen/restapi/operations"
+	"github.com/supervised-io/kov/pkg/handlers"
 )
 
 var (
@@ -210,6 +213,27 @@ func (d *defaultApplication) Stop() error {
 
 func (d *defaultApplication) RegisterHandlers(api *operations.KovAPI) {
 	// Register the http handlers here
+	// configure the api here
+	api.JSONConsumer = runtime.JSONConsumer()
+	api.JSONProducer = runtime.JSONProducer()
+
+	api.CreateClusterHandler = operations.CreateClusterHandlerFunc((&handlers.CreateCluster{}).Handle)
+
+	api.ListClustersHandler = operations.ListClustersHandlerFunc((&handlers.ListClusters{}).Handle)
+
+	api.DeleteClusterHandler = operations.DeleteClusterHandlerFunc(func(params operations.DeleteClusterParams) middleware.Responder {
+		return middleware.NotImplemented("operation .DeleteCluster has not yet been implemented")
+	})
+	api.GetTaskHandler = operations.GetTaskHandlerFunc(func(params operations.GetTaskParams) middleware.Responder {
+		return middleware.NotImplemented("operation .GetTask has not yet been implemented")
+	})
+
+	api.UpdateClusterHandler = operations.UpdateClusterHandlerFunc(func(params operations.UpdateClusterParams) middleware.Responder {
+		return middleware.NotImplemented("operation .UpdateCluster has not yet been implemented")
+	})
+
+	api.ServerShutdown = func() {}
+
 }
 
 // Logger is what your logrus-enabled library should take, that way

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -13,7 +13,6 @@ produces:
   - application/json
 
 schemes:
-  - http
   - https
 
 parameters:

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -105,7 +105,7 @@ paths:
           schema:
             $ref: '#/definitions/clusterUpdateConfig'
       responses:
-        204:
+        202:
           description: update cluster task has been accepted
           schema:
             $ref: '#/definitions/taskId'
@@ -127,7 +127,7 @@ paths:
           type: string
           x-nullable: false
       responses:
-        204:
+        202:
           description: delete cluster task has been accepted
           schema:
             $ref: '#/definitions/taskId'

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -13,6 +13,7 @@ produces:
   - application/json
 
 schemes:
+  - http
   - https
 
 parameters:


### PR DESCRIPTION
This PR introduces "dummy" implementations of the api handlers instead of the 'operation not implemented'. The purpose is to make the CLI testable